### PR TITLE
Double message event

### DIFF
--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
@@ -256,22 +256,6 @@ public class ImplMessage implements Message {
                     api.removeMessage(message);
                     logger.debug("Deleted message (id: {}, author: {}, content: \"{}\")",
                             getId(), getAuthor(), getContent());
-                    // call listener
-                    api.getThreadPool().getSingleThreadExecutorService("listeners").submit(new Runnable() {
-                        @Override
-                        public void run() {
-                            List<MessageDeleteListener> listeners = api.getListeners(MessageDeleteListener.class);
-                            synchronized (listeners) {
-                                for (MessageDeleteListener listener : listeners) {
-                                    try {
-                                        listener.onMessageDelete(api, message);
-                                    } catch (Throwable t) {
-                                        logger.warn("Uncaught exception in MessageDeleteListener!", t);
-                                    }
-                                }
-                            }
-                        }
-                    });
                     return null;
                 } catch (Exception e) {
                     return e;


### PR DESCRIPTION
The deleted code cause a double delete event, meaning that the same message got 2 delete events. In the event you would want to the bot to delete a message after for example posting a command it will cause a double call on the delete event causing the message signalled as delete 2 times.

Compiled and tested on a bot that logs deleted messages. After removing said code the double logging of the deleted message no longer occurred.